### PR TITLE
[main] Add tests for chapter 06

### DIFF
--- a/Ch06/Ch06.cabal
+++ b/Ch06/Ch06.cabal
@@ -8,3 +8,9 @@ library
         Exercises
     build-depends: base
     default-language: Haskell2010
+
+Test-Suite tests
+    main-is: Tests.hs
+    type: exitcode-stdio-1.0
+    build-depends: base, hspec, QuickCheck, Ch06
+    default-language: Haskell2010

--- a/Ch06/Tests.hs
+++ b/Ch06/Tests.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+import Test.Hspec
+import Test.QuickCheck
+
+import Exercises
+
+main :: IO ()
+main = hspec $ do
+  describe "length" $ do
+    it "behaves like Prelude.length" $ property $
+      \(xs :: [()]) -> Exercises.length xs == Prelude.length xs
+  describe "myFilter" $ do
+    it "behaves like filter" $ property $
+      \(xs :: [Int]) -> and [myFilter p xs == filter p xs | p <- intPredicates]
+  describe "mapIf" $ do
+    it "can be used to make all numbers even" $ property $
+      \(xs :: [Int]) -> all even $ mapIf odd (*2) xs
+    it "can be used to make all numbers odd" $  property $
+      \(xs :: [Int]) -> all odd $ mapIf even (1-) xs
+  describe "stretch" $ do
+    it "turns [1,2,3] into [1,1,2,2,3,3]" $ stretch [1,2,3] `shouldBe` [1,1,2,2,3,3]
+    it "doubles the length" $ property $
+      \(xs :: [()]) -> Prelude.length (stretch xs) == 2 * Prelude.length xs
+
+intPredicates = [even, odd, (>0), (<5)]


### PR DESCRIPTION
With this change, `stack test Ch06` causes some warnings that I don't know how to get rid of:
```
stack test Ch06
Ch06> build (lib + test)
Preprocessing library for Ch06-0.0.1..
Building library for Ch06-0.0.1..
[1 of 1] Compiling Exercises
Preprocessing test suite 'tests' for Ch06-0.0.1..
Building test suite 'tests' for Ch06-0.0.1..
            
<no location info>: warning: [-Wmissing-home-modules]
    These modules are needed for compilation but not listed in your .cabal file's other-modules: 
[1 of 2] Compiling Exercises
        Exercises
[2 of 2] Compiling Main
            
<no location info>: warning: [-Wmissing-home-modules]
    These modules are needed for compilation but not listed in your .cabal file's other-modules: 
        Exercises
Linking .stack-work/dist/x86_64-linux-nix/Cabal-3.6.3.0/build/tests/tests ...
Ch06> copy/register
Installing library in /home/das-g/dev/learn/haskell/zurihac2023/BeginnerTrackExercises/.stack-work/install/x86_64-linux-nix/50c420fd800f669c88cba044ed1af41f50611d716df8332a9abd421ba3f98871/9.2.7/lib/x86_64-linux-ghc-9.2.7/Ch06-0.0.1-9cMKSwMS9UnH33VIcyyBtv
Registering library for Ch06-0.0.1..
Ch06> test (suite: tests)
            
Progress 1/2: Ch06
length
  behaves like Prelude.length [✔]
    +++ OK, passed 100 tests.
myFilter
  behaves like filter [✔]
    +++ OK, passed 100 tests.
mapIf
  can be used to make all numbers even [✔]
    +++ OK, passed 100 tests.
  can be used to make all numbers odd [✔]
    +++ OK, passed 100 tests.
stretch
  turns [1,2,3] into [1,1,2,2,3,3] [✔]
  doubles the length [✔]
    +++ OK, passed 100 tests.

Finished in 0.0030 seconds
6 examples, 0 failures
                  
Ch06> Test suite tests passed
Completed 2 action(s).
```